### PR TITLE
Add react router, page for Rest repository test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "axios": "^1.7.7",
         "penguin-client": "file:",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -1379,6 +1380,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3556,6 +3566,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "axios": "^1.7.7",
     "penguin-client": "file:",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,19 @@
-import ApiTest from "./ApiTest";
+import {
+  createBrowserRouter,
+  RouterProvider
+} from "react-router-dom";
+
+import ApiTest from "./pages/ApiTest";
 import { Box, ThemeProvider } from "@mui/material";
 import { theme } from "./util/theme";
+import WorkIndex from "./pages/WorkIndex";
+import Index from "./pages/Index";
+
+const router = createBrowserRouter([
+  { path: "/", element: <Index /> },
+  { path: "/test", element: <ApiTest />, },
+  { path: "/works", element: <WorkIndex /> }
+]);
 
 function App() {
   return (
@@ -14,7 +27,7 @@ function App() {
             minHeight: "100vh",
           }}
         >
-          <ApiTest />
+          <RouterProvider router={router} />
         </Box>
       </ThemeProvider>
     </>

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,4 @@ body {
   margin: 0;
   display: flex;
   place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
 }

--- a/src/pages/ApiTest.tsx
+++ b/src/pages/ApiTest.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { penguinApi } from "./util/axios";
+import { penguinApi } from "../util/axios";
 import { Button, Stack, Typography } from "@mui/material";
 
 export default function ApiTest() {
@@ -10,7 +10,7 @@ export default function ApiTest() {
     if (loading) return;
     setLoading(true);
     try {
-      const res = await penguinApi.get("/");
+      const res = await penguinApi.get("/api/test");
       setMsg(res.data.message);
     } catch (err) {
       console.error(err);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,0 +1,12 @@
+import { Button, Typography } from "@mui/material"
+import { Link } from "react-router-dom"
+
+export default function Index() {
+    return <>
+        <Typography variant="h1" component="div">Welcome to Penguin Tickets...</Typography>
+
+        <Button component={Link} to={"/test"}>Test API</Button>
+
+        <Button component={Link} to={"/works"}>Works Rest repository POC</Button>
+    </>;
+}

--- a/src/pages/WorkIndex.tsx
+++ b/src/pages/WorkIndex.tsx
@@ -26,8 +26,8 @@ export default function WorkIndex({ }) {
   }
 
   useEffect(() => {
-    penguinApi.get<SpringDataRestResponse<Work>>("/works")
-    .then(res => setWorks(res.data._embedded.works))
+    penguinApi.get<SpringDataRestResponse<Work, "works">>("/works")
+    .then(res => setWorks(res.data._embedded["works"]))
     .catch(err => console.log(err));
   }, [counter]);
 
@@ -39,6 +39,8 @@ export default function WorkIndex({ }) {
     <Typography variant="h1" component="div">
       Works (POC of Spring Rest repository feature):
     </Typography>
+
+    <p>You have added {counter} works</p>
 
     <ol>
       {workListItems}

--- a/src/pages/WorkIndex.tsx
+++ b/src/pages/WorkIndex.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { penguinApi } from "../util/axios";
+import Work from "../types/Work";
+import { Typography } from "@mui/material";
+import SpringDataRestResponse from "../types/SpringDataRestResponse";
+
+export default function WorkIndex({ }) {
+  const [works, setWorks] = useState<Work[]>([]);
+  const [counter, setCounter] = useState(0);
+
+  async function postWork(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const data = new FormData(e.currentTarget);
+    const title = data.get("title") as string;
+    const description = data.get("description") as string;
+
+    const newWork : Work = {
+      title: title,
+      description: description
+    }
+
+    penguinApi.post("/works", newWork)
+      .then(() => setCounter(counter + 1))
+      .catch(err => console.error(err));
+  }
+
+  useEffect(() => {
+    penguinApi.get<SpringDataRestResponse<Work>>("/works")
+    .then(res => setWorks(res.data._embedded.works))
+    .catch(err => console.log(err));
+  }, [counter]);
+
+  const workListItems = works.map(w => {
+    return <li>{w.title}</li>;
+  });
+
+  return <>
+    <Typography variant="h1" component="div">
+      Works (POC of Spring Rest repository feature):
+    </Typography>
+
+    <ol>
+      {workListItems}
+    </ol>
+
+    <div>
+      <h2>Make a work:</h2>
+
+      <form onSubmit={postWork}>
+        <label htmlFor="title">Name:</label>
+        <input required name="title" id="title" type="text"></input>
+        <label htmlFor="description">Description:</label>
+        <input required name="description" id="description" type="text"></input>
+
+        <button type="submit">Submit</button>
+      </form>
+    </div>
+  </>;
+}

--- a/src/pages/WorkIndex.tsx
+++ b/src/pages/WorkIndex.tsx
@@ -27,7 +27,7 @@ export default function WorkIndex({ }) {
 
   useEffect(() => {
     penguinApi.get<SpringDataRestResponse<Work, "works">>("/works")
-    .then(res => setWorks(res.data._embedded["works"]))
+    .then(res => setWorks(res.data._embedded.works))
     .catch(err => console.log(err));
   }, [counter]);
 

--- a/src/types/SpringDataRestResponse.tsx
+++ b/src/types/SpringDataRestResponse.tsx
@@ -1,0 +1,12 @@
+interface SpringDataRestResponse<T> {
+  _embedded: {
+    works: T[];
+  };
+  _links: {
+    self: {
+      href: string;
+    };
+  };
+}
+
+export default SpringDataRestResponse;

--- a/src/types/SpringDataRestResponse.tsx
+++ b/src/types/SpringDataRestResponse.tsx
@@ -1,6 +1,6 @@
-interface SpringDataRestResponse<T> {
+interface SpringDataRestResponse<T, K extends string> {
   _embedded: {
-    works: T[];
+    [key in K]: T[];
   };
   _links: {
     self: {

--- a/src/types/Work.tsx
+++ b/src/types/Work.tsx
@@ -1,0 +1,6 @@
+type Work = {
+    title: String,
+    description: String
+};
+
+export default Work;


### PR DESCRIPTION
Adds React router
Adds a "pages" folder for the page components routed to by React router
Add a type for the Spring repository REST response
Minimal example using the Rest repository API
Removed min-height and min-width from index.css