### PR TITLE
Email verification

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -270,9 +270,6 @@ function ResponsiveAppBar() {
                                 Get Started
                             </Button>
 
-                            <Button onClick={navigateToVerify}>
-                                Verify Email Test
-                            </Button>
                         </Stack>
                     )}
                 </Toolbar>

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -14,7 +14,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { Stack } from '@mui/material';
 import { useAuth } from '../util/auth/useAuth';
 import PenguinIcon from '../assets/penguins/penguin-icon.tsx';
-import {useSignUpNavigation, useLoginNavigation} from '../util/hooks/navigationUtilities.ts';
+import {useSignUpNavigation, useLoginNavigation, useVerifyNavigation} from '../util/hooks/navigationUtilities.ts';
 import {Link} from "react-router-dom";
 
 
@@ -48,6 +48,8 @@ function ResponsiveAppBar() {
     {/* Works the same as the signup navigation method */}
     /** Navigate to login page */
     const navigateToLogin  = useLoginNavigation();
+
+    const navigateToVerify = useVerifyNavigation();
 
 
     {/* We're grabbing the function for navigating to the signup page by calling the hook
@@ -266,6 +268,10 @@ function ResponsiveAppBar() {
 
                             <Button onClick={navigateToSignUp}>
                                 Get Started
+                            </Button>
+
+                            <Button onClick={navigateToVerify}>
+                                Verify Email Test
                             </Button>
                         </Stack>
                     )}

--- a/src/components/EmailVerificationCard.tsx
+++ b/src/components/EmailVerificationCard.tsx
@@ -5,7 +5,8 @@
     As well, the {onResendEmail}: EmailVerificationCardProps is taking the prop passed in and saving it to the
     onResendEmail variable
 
-    The divider is currently spanning the whole card; this can be changed by removing the calc and the negative left margin
+    The divider is currently not spanning the whole card; I think it looks more professional this way
+    It can be made to span the whole card by changing the sx on the divider to have width: 'calc(100% + 32px)', marginLeft: -2
      -- Aaron */}
 
 import React from 'react';
@@ -26,7 +27,7 @@ const EmailVerificationCard = ({ onResendEmail }: EmailVerificationCardProps) =>
                 <Typography variant="h4" align="center" color="black">
                     Please Verify Your Email
                 </Typography>
-                <Divider sx={{ borderWidth: 1, marginBottom: 2, width: 'calc(100% + 32px)', marginLeft: -2}} color="grey"/>
+                <Divider sx={{ borderWidth: 1, marginBottom: 2, width: '100%', marginLeft: 0}} color="grey"/>
                 <Typography variant="body1" align="center" color="black">
                     A verification link has been sent to your email. If you have not received the email, please press the resend button below.
                 </Typography>

--- a/src/components/EmailVerificationCard.tsx
+++ b/src/components/EmailVerificationCard.tsx
@@ -1,0 +1,42 @@
+{/* Using an interface for the onresendemail function
+    A function will have to be declared and passed to the card as a prop in the main page
+    This function will contain the logic for what happens on clicking the resend verification button
+    The arrow function syntax is -- () means it has no params, and => void means it returns nothing
+    As well, the {onResendEmail}: EmailVerificationCardProps is taking the prop passed in and saving it to the
+    onResendEmail variable
+
+    The divider is currently spanning the whole card; this can be changed by removing the calc and the negative left margin
+     -- Aaron */}
+
+import React from 'react';
+import {Card, CardContent, Typography, Button, Divider} from '@mui/material';
+
+
+interface EmailVerificationCardProps {
+    onResendEmail: () => void;
+    };
+
+const EmailVerificationCard = ({ onResendEmail }: EmailVerificationCardProps) => {
+    return (
+        <Card style={{width:'100%',
+                        maxWidth: '50vw',
+                        backgroundColor: '#ffffff',
+                        boxShadow: 2}}>
+            <CardContent sx={{padding: '16px'}}>
+                <Typography variant="h4" align="center" color="black">
+                    Please Verify Your Email
+                </Typography>
+                <Divider sx={{ borderWidth: 1, marginBottom: 2, width: 'calc(100% + 32px)', marginLeft: -2}} color="grey"/>
+                <Typography variant="body1" align="center" color="black">
+                    A verification link has been sent to your email. If you have not received the email, please press the resend button below.
+                </Typography>
+                <Button variant="contained" size="medium" style={{display: 'block', margin: '20px auto'}} onClick={onResendEmail}>
+                    Resend Email
+                </Button>
+                </CardContent>
+        </Card>
+        );
+    };
+
+export default EmailVerificationCard;
+

--- a/src/pages/EmailVerificationPage.tsx
+++ b/src/pages/EmailVerificationPage.tsx
@@ -1,0 +1,30 @@
+{/* This currently has a placeholder popup for the resend verification button
+    Somebody will have to wire the API calls to send and resend verification emails -- Aaron*/}
+
+
+import React from 'react';
+import { Box } from '@mui/material';
+import EmailVerificationCard from '../components/EmailVerificationCard';
+
+const EmailVerificationPage = () => {
+    const handleResendEmail = () => {
+            window.alert("Verification Email sent! TODO: Implement call to backend!");
+        };
+
+
+    return (
+        <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            minHeight="80vh"
+            >
+
+                <EmailVerificationCard onResendEmail={handleResendEmail} />
+
+            </Box>
+
+        );
+    };
+
+export default EmailVerificationPage;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,6 +6,7 @@ import WorkIndex from './pages/WorkIndex';
 import SignIn from './pages/SignIn'; //this imports the SignIn function from the SignIn.tsx file -- Aaron
 import Layout from './components/Layout';  // Import the Layout component
 import SignUp from './pages/SignUp';
+import EmailVerificationPage from './pages/EmailVerificationPage';
 
 //this gets used by app.tsx
 export const router = createBrowserRouter([
@@ -23,6 +24,7 @@ export const router = createBrowserRouter([
             { path: '/works', element: <WorkIndex /> },
             { path: '/signin', element: <SignIn /> },
             { path: '/register', element: <SignUp /> },
+            { path: '/verify', element: <EmailVerificationPage />}
         ],
     },
 ]);

--- a/src/util/hooks/navigationUtilities.ts
+++ b/src/util/hooks/navigationUtilities.ts
@@ -21,6 +21,14 @@ export const useSignUpNavigation = (): (() => void) => {
     };
 };
 
+export const useVerifyNavigation = (): (() => void) => {
+    const navigate: NavigateFunction = useNavigate();
+
+    return () => {
+        navigate('/verify');
+    };
+};
+
 /** Same as the sign up navigation function but navigates to the login page */
 export const useLoginNavigation = (): (() => void) => {
     const navigate: NavigateFunction = useNavigate();


### PR DESCRIPTION
Created a boilerplate email verification page. Nothing fancy, but will look decent and do the trick. If you want to test it, go to /verify. 

Looks like:
![Screenshot 2024-12-03 080041](https://github.com/user-attachments/assets/96cabcd3-733a-47fd-af35-e94cfca6dd1f)


I made the choice to have the divider not span the full length of the card after experimenting with both styles. This can be changed easily, and I left a note in the comments as to how to make the divider span the whole card if we decide that's a better style.